### PR TITLE
'smartindent' is only for C and obsolete (replaced by 'cindent'); turning

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -5,7 +5,6 @@ set softtabstop=2
 set backspace=indent,eol,start
 set expandtab
 set autoindent
-set smartindent
 set smarttab
 
 " Misc


### PR DESCRIPTION
'smartindent' is only for C and obsolete (replaced by 'cindent'); turning it on in your .vimrc will make it active for filetypes that don't have their own indent scripts (which you probably don't want)
